### PR TITLE
setup.py: exclude also all subpackages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
     author_email='myselfasunder@gmail.com',
     url='https://github.com/dsoprea/GDriveFS',
     license='GPL 2',
-    packages=setuptools.find_packages(exclude=['dev', 'tests']),
+    packages=setuptools.find_packages(exclude=['dev', 'dev.*', 'tests', 'tests.*']),
     include_package_data=True,
     package_data={
         'gdrivefs': [


### PR DESCRIPTION
While packaging this tool for Gentoo I came across an issue where `tests.gdtool` package was installed. Installing `tests.*` packages is forbidden by packaging guidelines so I applied the following fix, which also covers all future cases.